### PR TITLE
added excluded directories for PomXmlUpdater

### DIFF
--- a/src/main/groovy/org/arquillian/spacelift/gradle/maven/PomXmlUpdater.groovy
+++ b/src/main/groovy/org/arquillian/spacelift/gradle/maven/PomXmlUpdater.groovy
@@ -14,7 +14,7 @@ class PomXmlUpdater extends Task<Object, Void> {
         def project = GradleSpacelift.currentProject()
         this.xmlFiles = project.fileTree("${dir}") {
             include "**/pom.xml"
-            exclude "${project.spacelift.localRepository}/**", "**/target/**"
+            exclude "${project.spacelift.localRepository}/**", "${project.spacelift.workspace}", "${project.spacelift.installationsDir}", "**/target/**"
         }
         this
     }


### PR DESCRIPTION
@kpiwko 

added exclusion directories to PomXmlUpdater when your workspace is in the same directory as your build.gradle.
