### PR TITLE
expansion of key for environment props of Maven and Cordova executor

### DIFF
--- a/src/main/groovy/org/arquillian/spacelift/gradle/cordova/CordovaExecutor.groovy
+++ b/src/main/groovy/org/arquillian/spacelift/gradle/cordova/CordovaExecutor.groovy
@@ -35,7 +35,7 @@ class CordovaExecutor extends Task<Object, Void> {
     }
 
     def env(key, value) {
-        this.env << [key:value]
+        this.env << ["${key}":value]
         this
     }
 

--- a/src/main/groovy/org/arquillian/spacelift/gradle/maven/MavenExecutor.groovy
+++ b/src/main/groovy/org/arquillian/spacelift/gradle/maven/MavenExecutor.groovy
@@ -142,7 +142,7 @@ class MavenExecutor extends Task<Object, Void>{
     }
 
     def env(key, value) {
-        this.env << [key:value]
+        this.env << ["${key}":value]
         this
     }
 


### PR DESCRIPTION
@kpiwko 

The second version of env method works ok and that one is used everywhere so there is nothing to change in other projects.

This method adds into a map an entry with a key of name "key" everytime. It has to be expanded to the value.
