### PR TITLE
Refactored OpenShift related classes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ buildscript {
 
 dependencies {
     compile gradleApi()
-    compile 'org.codehaus.groovy:groovy-all:2.3.6'
+    compile 'org.codehaus.groovy:groovy-all:2.3.9'
 
     // commons lang is used to do platform checks
     compile 'org.apache.commons:commons-lang3:3.1'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.2-bin.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.3-bin.zip

--- a/src/main/groovy/org/arquillian/spacelift/gradle/openshift/CreateOpenShiftCartridge.groovy
+++ b/src/main/groovy/org/arquillian/spacelift/gradle/openshift/CreateOpenShiftCartridge.groovy
@@ -1,0 +1,168 @@
+package org.arquillian.spacelift.gradle.openshift
+
+import org.arquillian.spacelift.Spacelift
+import org.arquillian.spacelift.gradle.GradleSpaceliftDelegate
+import org.arquillian.spacelift.process.ProcessResult
+import org.arquillian.spacelift.task.Task
+
+class CreateOpenShiftCartridge extends Task<Object, ProcessResult> {
+
+    private String name
+    private String namespace
+    private String server
+    private String gear
+    private boolean isScaling = false
+    private boolean noGit = true
+    private boolean force = false
+    private boolean ignoreIfExists = false
+    private List<String> cartridges = new ArrayList<String>();
+    private String repo
+    private File gitSsh
+
+    // credentials
+    def password
+    def login
+    def token
+
+    @Override
+    protected ProcessResult process(Object unused) throws Exception {
+
+        // delete app if it exists
+        if(force) {
+            def command = Spacelift.task('rhc')
+                    .parameters("app", "delete", "--confirm", name, "-n", namespace)
+                    // if app is not present, it will fail with 101
+                    .shouldExitWith(0, 101)
+                    .interaction(GradleSpaceliftDelegate.ECHO_OUTPUT)
+
+            if(login) {
+                command.parameters("-l", login)
+            }
+            if(password) {
+                command.parameters("-p", password)
+            }
+            if(token) {
+                command.parameters("--token", token)
+            }
+
+            command.execute().await()
+        }
+
+        def command = Spacelift.task('rhc')
+
+        if (gitSsh) {
+            command.addEnvironment(["GIT_SSH": gitSsh.getAbsolutePath()])
+        }
+
+        command.parameters("app", "create")
+
+        command.parameters("-a", name)
+        command.parameters("-n", namespace)
+
+        if(gear) {
+            command.parameters("-g", gear)
+        }
+        if(isScaling) {
+            command.parameter("-s")
+        }
+        if(noGit) {
+            command.parameter("--no-git")
+        }
+        if(server) {
+            command.parameters("--server", server)
+        }
+        if(login) {
+            command.parameters("-l", login)
+        }
+        if(password) {
+            command.parameters("-p", password)
+        }
+        if(token) {
+            command.parameters("--token", token)
+        }
+        if (repo) {
+            command.parameters("--repo", repo)
+        }
+        if(ignoreIfExists) {
+            command.shouldExitWith(0,1)
+        }
+
+        command.parameters(cartridges)
+
+        ProcessResult result = command.interaction(GradleSpaceliftDelegate.ECHO_OUTPUT).execute().await()
+
+        result
+    }
+
+    CreateOpenShiftCartridge ignoreIfExists(boolean ignoreIfExists) {
+        this.ignoreIfExists = ignoreIfExists
+        this
+    }
+
+    CreateOpenShiftCartridge force(boolean force) {
+        this.force = force
+        this
+    }
+
+    CreateOpenShiftCartridge named(String name) {
+        this.name = name
+        this
+    }
+
+    CreateOpenShiftCartridge cartridges(CharSequence... cartridges) {
+        this.cartridges.addAll(cartridges)
+        this
+    }
+
+    CreateOpenShiftCartridge sized(String gear) {
+        this.gear = gear
+        this
+    }
+
+    CreateOpenShiftCartridge at(String namespace) {
+        this.namespace = namespace
+        this
+    }
+
+    CreateOpenShiftCartridge server(String server) {
+        this.server = server
+        this
+    }
+
+    CreateOpenShiftCartridge scale(boolean scale) {
+        this.isScaling = scale
+        this
+    }
+
+    CreateOpenShiftCartridge checkout(boolean checkout) {
+        this.noGit = !checkout
+        this
+    }
+
+    CreateOpenShiftCartridge username(String username) {
+        this.login = username
+        this
+    }
+
+    CreateOpenShiftCartridge password(String password) {
+        this.password = password
+        this
+    }
+
+    CreateOpenShiftCartridge token(String token) {
+        this.token = token
+        this
+    }
+
+    CreateOpenShiftCartridge repo(String repo) {
+        this.repo = repo
+        this
+    }
+
+    CreateOpenShiftCartridge gitSsh(File gitSsh) {
+        if (gitSsh && gitSsh.exists() && gitSsh.isFile()) {
+            this.gitSsh = gitSsh
+        }
+        this
+    }
+}

--- a/src/main/groovy/org/arquillian/spacelift/gradle/openshift/OpenShiftMetadata.groovy
+++ b/src/main/groovy/org/arquillian/spacelift/gradle/openshift/OpenShiftMetadata.groovy
@@ -1,0 +1,101 @@
+package org.arquillian.spacelift.gradle.openshift
+
+/**
+ * @author <a href="mailto:smikloso@redhat.com">Stefan Miklosovic</a>
+ *
+ */
+class OpenShiftMetadata {
+
+    private String url
+    private String ssh
+    private String git
+    private String cloned
+    private String dbuser
+    private String dbpassword
+    private String dbname
+
+    def setUrl(String url) {
+        this.url = url
+    }
+
+    def setSsh(String ssh) {
+        this.ssh = ssh
+    }
+
+    def setGit(String git) {
+        this.git = git
+    }
+
+    def setCloned(String cloned) {
+        this.cloned = cloned
+    }
+
+    def setDBUser(String dbuser){
+        this.dbuser = dbuser
+    }
+
+    def setDBPassword(String dbpassword){
+        this.dbpassword = dbpassword
+    }
+
+    def setDBName(String dbname) {
+        this.dbname = dbname
+    }
+
+    public String getDbuser() {
+        return dbuser
+    }
+
+    public void setDbuser(String dbuser) {
+        this.dbuser = dbuser
+    }
+
+    public String getDbpassword() {
+        return dbpassword
+    }
+
+    public void setDbpassword(String dbpassword) {
+        this.dbpassword = dbpassword
+    }
+
+    public String getDbname() {
+        return dbname
+    }
+
+    public void setDbname(String dbname) {
+        this.dbname = dbname
+    }
+
+    public String getUrl() {
+        return url
+    }
+
+    public String getSsh() {
+        return ssh
+    }
+
+    public String getGit() {
+        return git
+    }
+
+    public String getCloned() {
+        return cloned
+    }
+
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder()
+
+        sb.append("URL: ").append(url).append("\n")
+                .append("SSH to: ").append(ssh).append("\n")
+                .append("Git remote: ").append(git).append("\n")
+                .append("Cloned to: ").append(cloned).append("\n")
+                .append("Root User: ").append(dbuser).append("\n")
+                .append("Root Password: ").append(dbpassword).append("\n")
+                .append("Database Name: ").append(dbname).append("\n")
+
+
+        return sb.toString()
+    }
+}

--- a/src/main/groovy/org/arquillian/spacelift/gradle/openshift/OpenShiftMetadataTask.groovy
+++ b/src/main/groovy/org/arquillian/spacelift/gradle/openshift/OpenShiftMetadataTask.groovy
@@ -1,0 +1,53 @@
+package org.arquillian.spacelift.gradle.openshift
+
+import org.arquillian.spacelift.process.ProcessResult
+import org.arquillian.spacelift.task.Task
+
+/**
+ *
+ * @author <a href="mailto:smikloso@redhat.com">Stefan Miklosovic</a>
+ *
+ */
+class OpenShiftMetadataTask extends Task<ProcessResult, OpenShiftMetadata> {
+
+    private ProcessResult processResult
+
+    @Override
+    protected OpenShiftMetadata process(ProcessResult processResult) throws Exception {
+
+        OpenShiftMetadata metadata = new OpenShiftMetadata()
+
+        if (!processResult || processResult.output().isEmpty()) {
+            return metadata
+        }
+
+        this.processResult = processResult
+
+        metadata.setUrl(get("URL:"))
+        metadata.setSsh(get("SSH to:"))
+        metadata.setGit(get("Git remote:"))
+        metadata.setCloned(get("Cloned to:"))
+        metadata.setDBUser(get("Root User:"))
+        metadata.setDBPassword(get("Root Password:"))
+        metadata.setDBName(get("Database Name:"))
+
+        metadata
+    }
+
+    private get(String what) {
+        String result
+
+        for (String line : processResult.output()) {
+            if (line.contains(what)) {
+                String[] parse = line.split(": ")
+
+                if (parse.length == 2) {
+                    result = parse[1].trim()
+                }
+                break
+            }
+        }
+
+        result
+    }
+}

--- a/src/test/groovy/org/arquillian/spacelift/gradle/CreateOpenShiftCartridgeTest.groovy
+++ b/src/test/groovy/org/arquillian/spacelift/gradle/CreateOpenShiftCartridgeTest.groovy
@@ -4,7 +4,7 @@ import org.arquillian.spacelift.Spacelift
 import org.arquillian.spacelift.process.ProcessResult
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
-import org.arquillian.spacelift.gradle.openshift.CreateOpenshiftCartridge;
+import org.arquillian.spacelift.gradle.openshift.CreateOpenShiftCartridge;
 import org.arquillian.spacelift.gradle.utils.KillJavas
 import org.junit.Ignore;
 import org.junit.Test
@@ -18,7 +18,7 @@ import static org.junit.Assert.assertThat
  *
  */
 @Ignore
-public class CreateOpenshiftCartridgeTest {
+public class CreateOpenShiftCartridgeTest {
 
     @Test
     public void createCart() {
@@ -37,7 +37,7 @@ public class CreateOpenshiftCartridgeTest {
         }
 
         // kill servers
-        Spacelift.task(CreateOpenshiftCartridge)
+        Spacelift.task(CreateOpenShiftCartridge)
                 .named('foobar')
                 .at('mobileqa')
                 .sized("small")

--- a/src/test/groovy/org/arquillian/spacelift/gradle/ScriptParsingTest.groovy
+++ b/src/test/groovy/org/arquillian/spacelift/gradle/ScriptParsingTest.groovy
@@ -1,0 +1,78 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the 
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.arquillian.spacelift.gradle
+
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Test
+
+/**
+ * @author <a href="mailto:smikloso@redhat.com">Stefan Miklosovic</a>
+ *
+ */
+public class ScriptParsingTest {
+    @Test
+    public void executeTestReport() {
+        Project project = ProjectBuilder.builder().build()
+
+        project.apply plugin: 'spacelift'
+
+        project.repositories { mavenCentral() }
+
+        project.configurations { junitreport }
+
+        project.dependencies { junitreport 'org.apache.ant:ant-junit:1.9.4' }
+
+        project.spacelift {
+            tests {
+                openshiftIntegrationTests {
+                    execute {
+                        println "openshiftIntegrationTests"
+                    }
+                }
+                localIntegrationTests {
+                    execute {
+                        printn "localIntegrationTests"
+                    }
+                }
+            }
+            tools {
+            }
+            profiles {
+                openshift {
+                    enabledInstallations 'a', 'b'
+                    tests 'openshiftIntegrationTests'
+                }
+                local {
+                    tests 'localIntegrationTests'
+                }
+                eap6(inherits: local) {
+                    enabledInstallations 'c', 'd'
+                }
+        
+            }
+            installations {
+                a {}
+                b {}
+                c {}
+                d {}
+            }
+        }
+
+        project.getTasks()['init'].execute()
+    }
+}


### PR DESCRIPTION
@kpiwko 

UPSOpenShiftInstallation will be part of the UPS integration tests as such.

Right now integration tests fail on the error I posted you privately.

Updated to Gradle 2.3 and Groovy 2.3.9 (Gradle 2.3 comes with that Groovy).

The latest awaitility-groovy 1.6.3 comes with Groovy 2.3.7 so we would exclude that groovy-all dependency from UPS integration tests.